### PR TITLE
Fix one minor typo "inspect and explore" chapter

### DIFF
--- a/ls00_inspect-explore.Rmd
+++ b/ls00_inspect-explore.Rmd
@@ -36,7 +36,7 @@ You need to develop a toolkit for list inspection. Be on the look out for:
   * Are the components homogeneous, i.e. do they have the same overall structure, albeit containing different data?
   * Note the length, names, and types of the constituent objects.
   
-> I have no idea what's in this list or what it's structure is! Please send help.
+> I have no idea what's in this list or what its structure is! Please send help.
 
 Understand this is **situation normal**, especially when your list comes from querying a poorly documented API. This is often true even when your list has been created completely within R. How many of us perfectly understand the structure of a fitted linear model object? You just have to embark on a voyage of discovery and figure out what's in there. Happy trails.
 


### PR DESCRIPTION
Replace `it's` by `its`.